### PR TITLE
Add optimized sha1 hex encoding version and add building instructions

### DIFF
--- a/elixir/thanabodee/CMakeLists.txt
+++ b/elixir/thanabodee/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.19)
+project(encoding C)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(ERLANG_ROOT_DIR /usr/local/Cellar/erlang/23.2.5/lib/erlang)
+include_directories(${ERLANG_ROOT_DIR}/usr/include/)
+add_library(encoding_nif SHARED encoding_nif.c)
+set_target_properties(encoding_nif
+	PROPERTIES
+	SUFFIX .so)
+target_link_options(encoding_nif PUBLIC -undefined dynamic_lookup -shared)

--- a/elixir/thanabodee/README.md
+++ b/elixir/thanabodee/README.md
@@ -1,0 +1,40 @@
+# SHA1 chanllenges with Elixir
+
+## Building
+
+For running `sha1.exs`, you can run by elixir directly:
+
+```shell
+$ time elixir sha1.exs
+```
+
+But for `sha1_2.exs`, it requires `cmake` to building c code. Here is the build instructions:
+
+```shell
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make
+$ cd ..
+$ time elixir sha1_2.exs
+```
+
+If you're not using homebrew to install `erlang`. You can change erlang root by edit `CMakeLists.txt`:
+
+```diff
+diff --git a/elixir/thanabodee/CMakeLists.txt b/elixir/thanabodee/CMakeLists.txt
+index 802c845..691decf 100644
+--- a/elixir/thanabodee/CMakeLists.txt
++++ b/elixir/thanabodee/CMakeLists.txt
+@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
+ project(encoding C)
+
+ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+-set(ERLANG_ROOT_DIR /usr/local/Cellar/erlang/23.2.5/lib/erlang)
++set(ERLANG_ROOT_DIR <your_erlang_root_dir>)
+ include_directories(${ERLANG_ROOT_DIR}/usr/include/)
+ add_library(encoding_nif SHARED encoding_nif.c)
+ set_target_properties(encoding_nif
+```
+
+Change the `<your_erlang_root_dir>` to proper path.

--- a/elixir/thanabodee/encoding_nif.c
+++ b/elixir/thanabodee/encoding_nif.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <erl_nif.h>
+#include <stdio.h>
+
+static char hextable[] = "0123456789abcdef";
+
+static ERL_NIF_TERM hex_nif(ErlNifEnv *env, int argc,
+                            const ERL_NIF_TERM argv[]) {
+  int i, j;
+  size_t hexlen;
+  ErlNifBinary src, dst;
+
+  assert(argc == 1);
+  assert(enif_is_binary(env, argv[0]));
+  assert(enif_inspect_binary(env, argv[0], &src));
+
+  hexlen = src.size * 2;
+  assert(enif_alloc_binary(hexlen, &dst));
+  for (i = 0, j = 0; i < src.size; i++) {
+    dst.data[j] = hextable[src.data[i] >> 4];
+    dst.data[j + 1] = hextable[src.data[i] & 0x0f];
+    j += 2;
+  }
+  return enif_make_binary(env, &dst);
+}
+
+static ErlNifFunc nif_funcs[] = {
+    {"hex", 1, hex_nif},
+};
+
+ERL_NIF_INIT(Elixir.SHA1.Encoding, nif_funcs, NULL, NULL, NULL, NULL);

--- a/elixir/thanabodee/sha1_2.exs
+++ b/elixir/thanabodee/sha1_2.exs
@@ -1,0 +1,18 @@
+defmodule SHA1.Encoding do
+  @on_load  :load_nifs
+
+  def load_nifs do
+    :erlang.load_nif("./build/libencoding_nif", 0)
+  end
+
+  def hex(_data) do
+    raise "NIF hex/1 not implemented"
+  end
+end
+
+1..5_555_555_555
+|> Enum.reduce("clubhouse", fn _i, data ->
+  :crypto.hash(:sha, data)
+  |> SHA1.Encoding.hex()
+end)
+|> IO.puts()


### PR DESCRIPTION
This changes optimized by implementing hex encoding in c (using Erlang
NIF). The results should be better.

For building tools it's requires cmake to building shared library and
erlang for pointing to include directory.